### PR TITLE
fix: trying to add correct css footer icons in lightmode/darkmode

### DIFF
--- a/src/components/ui/Footer.jsx
+++ b/src/components/ui/Footer.jsx
@@ -1,32 +1,41 @@
 function Footer() {
   return (
-    <footer class="text-center flex-row gap-6">
-      <h5 class="text-[var(--h5-size)] bold">
-        Juniors<img src="src/assets/ducky1.svg" class="w-0.5 inline align-baseline"></img>dev
+    <footer className="text-center flex-row gap-6">
+      <h5 className="text-[var(--h5-size)] bold">
+        Juniors<img src="src/assets/ducky1.svg" className="w-0.5 inline align-baseline"></img>dev
       </h5>
-      <p class="text-[var(--text-caption-size)] bold">We Build, Work and Win Together</p>
-      <p class="text-[var(--text-body-size)]">Follow Us</p>
-      <div class="flex gap-6 py-4 justify-center">
+      <p className="text-[var(--text-caption-size)] bold">We Build, Work and Win Together</p>
+      <p className="text-[var(--text-body-size)]">Follow Us</p>
+      <div className="flex gap-6 py-4 justify-center">
         {/* <img
           src="src/assets/discord-simple.svg"
           alt="discord link"
-          class="invert-100 w-6 h-6"
+          class=" w-6 h-6"
         ></img> */}
         <img
           src="src/assets/facebook-simple.svg"
           alt="facebook link"
-          class="invert-100 w-6 h-6"
+          className="w-6 h-6 icon"
         ></img>
         <img
           src="src/assets/instagram-simple.svg"
           alt="instagram link"
-          class="invert-100 w-6 h-6"
+          className="w-6 h-6 icon"
         ></img>
-        <img src="src/assets/linkedin-darkmode.png" alt="linkedin link" class="w-6 h-6"></img>
-        <img src="src/assets/github-simple.svg" alt="github link" class="invert-100 w-6 h-6"></img>
+        <img
+          src="src/assets/linkedin-lightmode.png"
+          alt="linkedin link"
+          className="w-6 h-6 dark:hidden"
+        ></img>
+        <img
+          src="src/assets/linkedin-darkmode.png"
+          alt="linkedin link"
+          className="w-6 h-6 hidden dark:block"
+        ></img>
+        <img src="src/assets/github-simple.svg" alt="github link" className="w-6 h-6 icon"></img>
       </div>
-      <div class="pb-4">Language toggle</div>
-      <p class="text-[var(--text-caption-size)]">© 2025 Juniors.dev | All rights reserved</p>
+      <div className="pb-4">Language toggle</div>
+      <p className="text-[var(--text-caption-size)]">© 2025 Juniors.dev | All rights reserved</p>
     </footer>
   );
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-
+@custom-variant dark (&:where(.dark, .dark *));
 /* Headings = Sora Bold */
 .heading,
 h1,
@@ -83,7 +83,7 @@ p {
 :root {
   line-height: 1.5;
   font-weight: 400;
-  color-scheme: light dark;
+  color-scheme: light;
   color: var(--color-primary-nightwing-hex);
   background-color: var(--color-accent-eggshell-hex);
   font-synthesis: none;
@@ -96,6 +96,10 @@ p {
   color-scheme: dark;
   color: var(--color-accent-eggshell-hex);
   background-color: var(--color-primary-nightwing-hex);
+}
+.dark .icon {
+  color-scheme: dark;
+  filter: invert(100%);
 }
 
 a {


### PR DESCRIPTION
Icons were displayed as inverted (white color) in the default lightmode as well as  darkmode.
This ticket and PR is my attempt at fixing that. Results so far icons are correct color in lightmode. 

- Changed the classes and tried only invert the icons when in darkmode with tailwinds dark:invert. 
- added both lightmode version and darkmode version of linkedin icon image
- changed from class to className (bc of React)


The icons are now a dark color in lightmode, and .. not inverting in darkmode. Maybe it will work correct when the light/dark toggle on the page is finished? Please enlighten me. 🙏