### PR TITLE
Refactor Suggestion: replace services carousel with responsive grid layout

### DIFF
--- a/src/pages/Home/sections/Services.jsx
+++ b/src/pages/Home/sections/Services.jsx
@@ -11,7 +11,7 @@ function OurServices() {
       <h2 className="text-primary-800">{t.heading}</h2>
 
       <div className="relative services-section__container">
-        <div className="services-rail relative md:me-6">
+        <div className="services-rail relative">
           {serviceCards.map((card) => {
             const content = card[language];
 

--- a/src/pages/Home/sections/Services.jsx
+++ b/src/pages/Home/sections/Services.jsx
@@ -10,8 +10,8 @@ function OurServices() {
     <Section className="bg-primary-100 relative">
       <h2 className="text-primary-800">{t.heading}</h2>
 
-      <div className="relative services-section__container">
-        <div className="services-rail relative">
+      <div className="services-section__container">
+        <div className="services-rail">
           {serviceCards.map((card) => {
             const content = card[language];
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -310,16 +310,6 @@ body {
   color: var(--color-primary-50);
 }
 
-@media (min-width: 768px) {
-  .dark .services-section__container::after {
-    background: linear-gradient(to right, transparent, var(--color-roadmap-blue));
-  }
-
-  .dark .services-section__container::before {
-    background: linear-gradient(to left, transparent, var(--color-roadmap-blue));
-  }
-}
-
 .dark .mission-section {
   background-color: var(--color-roadmap-blue);
   color: var(--color-primary-50);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1182,7 +1182,7 @@ label {
   }
 
   .service-card {
-    @apply block max-w-lg overflow-hidden rounded-[0.3125rem] border border-primary-200 bg-off-white transition-colors duration-200;
+    @apply flex flex-col max-w-lg overflow-hidden rounded-[0.3125rem] border border-primary-200 bg-off-white transition-colors duration-200;
   }
 
   .service-card:hover {
@@ -1195,7 +1195,7 @@ label {
   }
 
   .service-card__panel {
-    @apply m-1 rounded-[0.1875rem] p-3.5 pt-4;
+    @apply flex-1 flex flex-col m-1 rounded-[0.1875rem] p-3.5 pt-4;
     min-height: 9rem;
   }
 
@@ -1212,9 +1212,8 @@ label {
   }
 
   .service-card__tags {
-    @apply mt-4 flex flex-wrap gap-2;
+    @apply mt-auto flex flex-wrap gap-2;
   }
-
   .service-card__footer {
     @apply flex items-center justify-between px-4 pb-4 pt-2;
   }
@@ -1243,10 +1242,6 @@ label {
       gap: 1rem;
       padding-top: 1.5rem;
       padding-bottom: 0.5rem;
-    }
-
-    .services-rail > * {
-      flex: 0 0 auto;
     }
 
     .service-card__panel {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1240,30 +1240,13 @@ label {
 
   @media (min-width: 768px) {
     .services-rail {
-      display: flex;
-      justify-content: start;
-      flex-wrap: nowrap;
       gap: 1rem;
-      overflow-x: auto;
       padding-top: 1.5rem;
       padding-bottom: 0.5rem;
-      scroll-snap-type: x mandatory;
-      -webkit-overflow-scrolling: touch;
-      scrollbar-width: none;
-    }
-
-    .services-rail::-webkit-scrollbar {
-      display: none;
     }
 
     .services-rail > * {
       flex: 0 0 auto;
-      scroll-snap-align: start;
-    }
-
-    .service-card {
-      width: 19rem;
-      scroll-snap-align: start;
     }
 
     .service-card__panel {
@@ -1289,37 +1272,18 @@ label {
       width: 1.25rem;
       height: 1.25rem;
     }
-
-    .services-section__container::after {
-      content: "";
-      position: absolute;
-      top: 1rem;
-      right: 0;
-      bottom: 0.5rem;
-      width: 3rem;
-      pointer-events: none;
-      background: linear-gradient(to right, transparent, var(--color-primary-100));
-    }
-    .services-section__container::before {
-      content: "";
-      position: absolute;
-      top: 1rem;
-      left: 0;
-      bottom: 0.5rem;
-      width: 3rem;
-      pointer-events: none;
-      background: linear-gradient(to left, transparent, var(--color-primary-100));
-    }
   }
 
   @media (min-width: 1024px) {
-    .service-card {
-      width: 22rem;
-    }
-
     .service-card__details {
       @apply mb-16;
       font-size: 1.875rem;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .services-rail {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
 


### PR DESCRIPTION
### #125 Includes these same changes. Suggest ignoring this and just review that instead

The carousel only contains 4 _(3)_ cards with no plans to add more as far as I know. On desktop, the 4th card was half-visible, making it look like there's more content to scroll through, but it's literally just the last half of that card. Pointless and not the best UX imo.
Pushing it as a simple suggestion/fix.


Before (Desktop) :
<img width="1478" height="513" alt="Screenshot 2026-04-10 185441" src="https://github.com/user-attachments/assets/e7648a29-42c8-467e-920a-c8131634af6f" />

After (Desktop):
<img width="1405" height="466" alt="Screenshot 2026-04-10 193525" src="https://github.com/user-attachments/assets/468c8874-d324-4a1c-b563-864ffd9bf892" />

(mobile/tablets still uses 1-2 col)