### PR TITLE
73 reusable mini hero component

### DIFF
--- a/src/features/UI/Hero/Hero.jsx
+++ b/src/features/UI/Hero/Hero.jsx
@@ -1,0 +1,59 @@
+/**
+ * Hero Layout component.
+ *
+ * Provides:
+ * - a reusable hero layout with a title and body text
+ * - responsive two-column layout on larger screens and stacked layout on mobile
+ * - optional CTA / extra content area  rendered below the main hero text via 'children'
+ *
+ * Intended usage:
+ * - pass localized `title` and `body` strings (e.g. from `useT(hero)`)
+ * - control background and text colors via `className` on the underlying `Section`
+ * - pass a CTA button (e.g. `NavIconButton`) or other elements as `children`
+ *
+ * @component
+ *
+ * @param {object} props
+ * @param {string} props.title - Main hero heading text rendered in an <h1>
+ * @param {string} props.body - Supporting hero body text rendered in a <p>
+ * @param {React.ReactNode} [props.children] - Optional extra content (CTA button, links, tags, etc.)
+ * @param {string} [props.className=""] - Classes applied to the outer `Section` (background, text color, etc.)
+ *
+ * @returns {JSX.Element}
+ *
+ * @example
+ * //simple hero without CTA
+ * <Hero
+ *    title="Work at juniors.dev"
+ *    body="Always looking for hungry developers and designers ready to grow and gain real work experience."
+ * className="bg-primary-800 text-off-white"
+ * />
+ *
+ * @example
+ * <Hero
+ *    title={t.title}
+ *    body={t.body}
+ *    className="bg-primary-800 text-off-white"
+ * >
+ *    <NavIconButton to="#contact" variant="nav" icon>
+ *      {t.cta}
+ *    </NavIconButton>
+ * </Hero>
+ */
+
+import Section from "../Section/Section.jsx";
+
+function Hero({ title, body, className = "", children }) {
+  return (
+    <Section className={className}>
+      <div className="mx-auto flex space-between max-w-4xl flex-col gap-14 text-left md:flex-row md:items-center md:justify-between">
+        <h1 className="max-w-[12ch]">{title}</h1>
+        <p className="text-subheading-2 max-w-3xl">{body}</p>
+      </div>
+
+      {children && <div className="mx-auto mt-8 max-w-4xl">{children}</div>}
+    </Section>
+  );
+}
+
+export default Hero;

--- a/src/features/UI/Hero/Hero.jsx
+++ b/src/features/UI/Hero/Hero.jsx
@@ -46,9 +46,11 @@ import Section from "../Section/Section.jsx";
 function Hero({ title, body, className = "", children }) {
   return (
     <Section className={className}>
-      <div className="mx-auto flex space-between max-w-4xl flex-col gap-14 text-left md:flex-row md:items-center md:justify-between">
+      <div className="mx-auto flex space-between  flex-col gap-14 text-left md:flex-row md:items-center md:justify-between">
         <h1 className="max-w-[12ch]">{title}</h1>
-        <p className="text-subheading-2 max-w-3xl">{body}</p>
+        <p className="text-subheading-2 max-w-md md:max-w-2xl text-balance md:text-pretty">
+          {body}
+        </p>
       </div>
 
       {children && <div className="mx-auto mt-8 max-w-4xl">{children}</div>}

--- a/src/pages/Home/sections/Hero.jsx
+++ b/src/pages/Home/sections/Hero.jsx
@@ -1,21 +1,16 @@
-import { Section, NavIconButton } from "../../../features/UI";
+import { NavIconButton } from "../../../features/UI";
+import Hero from "../../../features/UI/Hero/Hero.jsx";
 import { hero } from "../translations/hero";
 import { useT } from "../../../stores/languageStore";
 
 function HeroSection() {
   const t = useT(hero);
   return (
-    <Section className="bg-primary-800 text-off-white">
-      <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
-        <h1 className="max-w-[12ch]">{t.title}</h1>
-
-        <p className="text-subheading-2 mt-6 max-w-3xl">{t.body}</p>
-
-        <NavIconButton to="#contact" variant="nav" icon className="mt-8">
-          {t.cta}
-        </NavIconButton>
-      </div>
-    </Section>
+    <Hero title={t.title} body={t.body} className="bg-primary-800 text-off-white">
+      <NavIconButton to="#contact" variant="nav" icon>
+        {t.cta}
+      </NavIconButton>
+    </Hero>
   );
 }
 

--- a/src/pages/Home/sections/Hero.jsx
+++ b/src/pages/Home/sections/Hero.jsx
@@ -1,16 +1,20 @@
-import { NavIconButton } from "../../../features/UI";
-import Hero from "../../../features/UI/Hero/Hero.jsx";
+import { Section, NavIconButton } from "../../../features/UI";
 import { hero } from "../translations/hero";
 import { useT } from "../../../stores/languageStore";
 
 function HeroSection() {
   const t = useT(hero);
   return (
-    <Hero title={t.title} body={t.body} className="bg-primary-800 text-off-white">
-      <NavIconButton to="#contact" variant="nav" icon>
-        {t.cta}
-      </NavIconButton>
-    </Hero>
+    <Section className="bg-primary-800 text-off-white">
+      <div className="mx-auto flex max-w-4xl flex-col items-center text-center">
+        <h1 className="max-w-[12ch] text-balance">{t.title}</h1>
+
+        <p className="text-subheading-2 mt-6 max-w-3xl text-balance">{t.body}</p>
+        <NavIconButton to="#contact" variant="nav" icon className="mt-8">
+          {t.cta}
+        </NavIconButton>
+      </div>
+    </Section>
   );
 }
 

--- a/src/pages/WorkWithUs/WorkWithUs.jsx
+++ b/src/pages/WorkWithUs/WorkWithUs.jsx
@@ -1,40 +1,12 @@
+import WorkWithUsHeroSection from "./sections/WorkWithUsHeroSection";
+
 function WorkWithUs() {
   return (
     <>
-      <div className="flex flex-col baseline-start gap-4">
-        {/* <img src="/src/assets/placeholder-img.png" alt="placeholder image" /> */}
-        <h1 className="text-h1 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Heading 1
-        </h1>
-        <h2 className="text-h2 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Heading 2
-        </h2>
-        <h3 className="text-h3 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Heading 3
-        </h3>
-        <h3 className="text-subheading-1 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Sub-Heading 1
-        </h3>
-        <h4 className="text-subheading-2 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Sub-Heading 2
-        </h4>
-
-        <p className="text-body text-fg text-left text-pretty xs:text-center sm:text-center">
-          Empowering developers through community, <br className="hidden xs:block" />
-          collaboration and career opportunities.
-        </p>
-
-        <p className="text-label text-fg text-left text-pretty xs:text-center sm:text-center">
-          Empowering developers through community, <br className="hidden xs:block" />
-          collaboration and career opportunities.
-        </p>
-        <div className="text-center">
-          <button className="btn">Base</button>
-          <button className="btn btn-primary">Primary</button>
-          <button className="btn btn-secondary">Secondary</button>
-          <button className="btn btn-nav">Nav</button>
-        </div>
-      </div>
+      <WorkWithUsHeroSection />
+      {/* <RealExperience />
+      <WhatToExpect />
+      <WorkWithUsContact /> /> */}
     </>
   );
 }

--- a/src/pages/WorkWithUs/sections/WorkWithUsHeroSection.jsx
+++ b/src/pages/WorkWithUs/sections/WorkWithUsHeroSection.jsx
@@ -1,0 +1,12 @@
+// import { NavIconButton } from "../../../features/UI";
+import Hero from "../../../features/UI/Hero/Hero.jsx";
+import { hero } from "../translations/hero";
+import { useT } from "../../../stores/languageStore";
+
+function WorkWithUsHeroSection() {
+  const t = useT(hero);
+
+  return <Hero title={t.title} body={t.body} className="bg-primary-800 text-off-white" />;
+}
+
+export default WorkWithUsHeroSection;

--- a/src/pages/WorkWithUs/translations/hero.js
+++ b/src/pages/WorkWithUs/translations/hero.js
@@ -1,0 +1,10 @@
+export const hero = {
+  en: {
+    title: "Work at juniors.dev",
+    body: "Always looking for hungry developers and designers ready to grow and gain real work experience.",
+  },
+  no: {
+    title: "Jobb hos juniors.dev",
+    body: "Vi er alltid på jakt etter sultne utviklere og designere som vil vokse og få ekte arbeidserfaring.",
+  },
+};


### PR DESCRIPTION
This pull request introduces a reusable `Hero` layout component to standardize hero sections across the app and refactors both the Home and Work With Us pages to use this component. The changes improve code maintainability and consistency, and add support for localized hero content.

**Component abstraction and refactoring:**

* Added a new `Hero` component in `src/features/UI/Hero/Hero.jsx` that provides a customizable, responsive hero layout with support for title, body, and optional child elements (e.g., CTA buttons).
* Refactored the Home page hero section to use the new `Hero` component instead of duplicating layout and styling logic.
* Created a `WorkWithUsHeroSection` component that uses the new `Hero` component for the Work With Us page, replacing the previous placeholder content [[1]](diffhunk://#diff-f3a738453ada71bc9286c66b551c948c217fe6b28411944cef64882b93ce6eedR1-R12) [[2]](diffhunk://#diff-8a2860753028e1a5b4d70271dd2a17975c60194c730b403dff514505c26a88feR1-R9).

**Localization support:**

* Added a `hero` translation object in `src/pages/WorkWithUs/translations/hero.js` to provide localized hero text for English and Norwegian.