### PR TITLE
Integrate hCaptcha to Home page form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "juniors-dev",
       "version": "0.0.0",
       "dependencies": {
+        "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/vite": "^4.1.10",
         "lucide-react": "^0.554.0",
@@ -1192,6 +1193,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@hcaptcha/react-hcaptcha": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-2.0.2.tgz",
+      "integrity": "sha512-VbuH6VJ6m3BHmVBHs0fL9t+suZd7PQEqCzqL2BiUbBvbHI3XfvSgdiug2QiEPN8zskbPTIV/FfGPF53JCckrow==",
+      "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     ]
   },
   "dependencies": {
+    "@hcaptcha/react-hcaptcha": "^2.0.2",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/vite": "^4.1.10",
     "lucide-react": "^0.554.0",

--- a/src/pages/Home/sections/Contact.jsx
+++ b/src/pages/Home/sections/Contact.jsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import HCaptcha from "@hcaptcha/react-hcaptcha";
+import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Section, SubmitButton, InputField } from "../../../features/UI";
@@ -8,16 +9,20 @@ import { useT } from "../../../stores/languageStore";
 
 const WEB3FORMS_URL = "https://api.web3forms.com/submit";
 const ACCESS_KEY = import.meta.env.VITE_WEB3FORMS_ACCESS_KEY;
+const HCAPTCHA_SITEKEY = "50b2fe65-b00b-4b9e-ad62-3ba471098be2";
 
 if (!ACCESS_KEY) {
   console.error("VITE_WEB3FORMS_ACCESS_KEY is not set.");
 }
 
 function ContactSection() {
+  const captchaRef = useRef(null);
+
   const {
     register,
     handleSubmit,
     reset,
+    setValue,
     formState: { errors, touchedFields, isSubmitted, isSubmitting },
   } = useForm({
     resolver: zodResolver(contactSchema),
@@ -29,6 +34,7 @@ function ContactSection() {
       email: "",
       subject: "",
       message: "",
+      captchaToken: "",
     },
   });
 
@@ -37,9 +43,19 @@ function ContactSection() {
 
   const t = useT(contacts);
 
+  function handleCaptchaVerify(token) {
+    setValue("captchaToken", token, { shouldValidate: true });
+  }
+
+  function handleCaptchaExpire() {
+    setValue("captchaToken", "", { shouldValidate: isSubmitted });
+  }
+
   async function onSubmit(data) {
     setSubmitStatus("idle");
     setErrorMessage("");
+
+    const { captchaToken, ...fields } = data;
 
     try {
       const response = await fetch(WEB3FORMS_URL, {
@@ -51,7 +67,9 @@ function ContactSection() {
         body: JSON.stringify({
           access_key: ACCESS_KEY,
           from_name: "Juniors.dev website",
-          ...data,
+          form_type: "contact",
+          "h-captcha-response": captchaToken,
+          ...fields,
         }),
       });
 
@@ -65,8 +83,8 @@ function ContactSection() {
 
       if (result.success) {
         setSubmitStatus("success");
-        setErrorMessage("");
         reset();
+        captchaRef.current?.resetCaptcha();
       } else {
         setSubmitStatus("error");
         setErrorMessage(t.errorGeneric);
@@ -153,10 +171,24 @@ function ContactSection() {
                 {...register("message")}
                 inputClassName="resize-none"
               />
-              <div className="contact-form__actions">
-                <SubmitButton variant="primary" type="submit" icon={true} disabled={isSubmitting}>
-                  {isSubmitting ? t.sending : t.send}
-                </SubmitButton>
+              <div className="contact-form__message-footer">
+                <div className="contact-form__captcha">
+                  <HCaptcha
+                    sitekey={HCAPTCHA_SITEKEY}
+                    reCaptchaCompat={false}
+                    onVerify={handleCaptchaVerify}
+                    onExpire={handleCaptchaExpire}
+                    ref={captchaRef}
+                  />
+                  {errors.captchaToken ? (
+                    <p className="input-field__error">{t.captchaError}</p>
+                  ) : null}
+                </div>
+                <div className="contact-form__actions">
+                  <SubmitButton variant="primary" type="submit" icon={true} disabled={isSubmitting}>
+                    {isSubmitting ? t.sending : t.send}
+                  </SubmitButton>
+                </div>
               </div>
             </div>
           </div>

--- a/src/pages/Home/sections/schema/contactSchema.js
+++ b/src/pages/Home/sections/schema/contactSchema.js
@@ -1,10 +1,29 @@
 import { z } from "zod";
 
+const NAME_REGEX = /^[\p{L}\p{M}]+(?:[ '-][\p{L}\p{M}]+)*$/u;
+
 /** Contact section form — validation lives with this section. */
 export const contactSchema = z.object({
-  firstName: z.string().trim().min(1, "First name is required"),
-  lastName: z.string().trim().min(1, "Last name is required"),
-  email: z.string().trim().min(1, "Email is required").email("Enter a valid email address"),
-  subject: z.string().trim().min(1, "Subject is required"),
-  message: z.string().trim().min(1, "Message is required"),
+  firstName: z
+    .string()
+    .trim()
+    .min(1, "First name is required.")
+    .regex(NAME_REGEX, "First name can only contain letters."),
+  lastName: z
+    .string()
+    .trim()
+    .min(1, "Last name is required.")
+    .regex(NAME_REGEX, "Last name can only contain letters."),
+  email: z.string().trim().min(1, "Email is required.").email("Enter a valid email address."),
+  subject: z
+    .string()
+    .trim()
+    .min(1, "Subject is required.")
+    .max(100, "Subject must be 100 characters or less."),
+  message: z
+    .string()
+    .trim()
+    .min(1, "Message is required.")
+    .max(5000, "Message must be 5000 characters or less."),
+  captchaToken: z.string().min(1, "Please complete the captcha."),
 });

--- a/src/pages/Home/sections/schema/contactSchema.js
+++ b/src/pages/Home/sections/schema/contactSchema.js
@@ -25,5 +25,5 @@ export const contactSchema = z.object({
     .trim()
     .min(1, "Message is required.")
     .max(5000, "Message must be 5000 characters or less."),
-  captchaToken: z.string().min(1, "Please complete the captcha."),
+  captchaToken: z.string().min(1),
 });

--- a/src/pages/Home/translations/contact.js
+++ b/src/pages/Home/translations/contact.js
@@ -13,6 +13,7 @@ export const contacts = {
     successMessage: "Your message has been sent successfully.",
     errorGeneric: "Something went wrong. Please try again.",
     errorNetwork: "Could not reach the server. Check your connection and try again.",
+    captchaError: "Please complete the security check before sending.",
   },
   no: {
     heading: "Kontakt oss",
@@ -28,5 +29,6 @@ export const contacts = {
     successMessage: "Takk! Meldingen din er sendt.",
     errorGeneric: "Noe gikk galt. Prøv igjen senere.",
     errorNetwork: "Ingen internettilkobling. Sjekk tilkoblingen din og prøv igjen.",
+    captchaError: "Vennligst fullfør sikkerhetssjekken før du sender",
   },
 };

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -784,12 +784,15 @@ label {
   }
 
   .contact-form__message {
-    @apply col-span-1;
-    @apply md:flex md:gap-15;
+    @apply col-span-1 md:col-span-2;
   }
 
   .contact-form__message .input-field {
-    @apply w-full max-w-4xl;
+    @apply w-full;
+  }
+
+  .contact-form__message-footer {
+    @apply mt-4 flex items-center justify-between;
   }
 
   .contact-form__actions {


### PR DESCRIPTION
**Added:**
- Schema validation (name regex, field limits) to Home page (from About page schema #89 )
- `onExpire` handler to clear token when it times out, so an expired token isnt silently sent to Web3Forms
- Captcha resets after successful submission via `useRef`, so the widget doesn't show as verified if the user submits again

**Other differences from the About page implementation PR #89  :**
- Moved captcha validation into schema so the error shows inline near the widget, like the other fields, instead of in the top-level banner.
- Added captcha error message is in the translation files rather than hardcoded in English. Also removed the captcha word from the message as I dont think most people knows what that mean.
- Included `captchaToken` in `defaultValues` so `reset()` clears it properly after submission.
- Extracted the sitekey to a named constant at the top of the file.
- Changed layout to full-width stacked.  The form UI is already awkward , and there's probably better options on captcha placement than what i did here (last image below).

About page form:
<img width="1432" height="633" alt="Screenshot 2026-04-28 175102" src="https://github.com/user-attachments/assets/c9f76dc5-e250-4d70-88cd-e49f51cfd79b" />

Home page form (Layout option  from this branch):
<img width="1458" height="831" alt="Screenshot 2026-04-28 104257" src="https://github.com/user-attachments/assets/72a8764c-4c74-4e20-8ec9-883697551ad3" />

