### PR TITLE
feat: add roadmap

### DIFF
--- a/src/features/Roadmap/RoadmapItem.jsx
+++ b/src/features/Roadmap/RoadmapItem.jsx
@@ -1,0 +1,25 @@
+function RoadmapItem({ year, title, body, defaultOpen = true }) {
+  return (
+    <article className="grid grid-cols-[60px_64px_1fr] md:grid-cols-[120px_64px_1fr] gap-x-2 md:gap-x-6 items-start">
+      <p className="text-subheading-1 font-semibold text-slate-900 text-end">{year}</p>
+
+      {/* vertical connector + dot */}
+      <div className="relative flex h-full justify-center ">
+        <span className="absolute -top-8 bottom-0 w-0.5 bg-lime-700" aria-hidden="true" />
+        <span
+          className="relative z-10 mt-1 block h-9 w-9 rounded-full border-2 border-lime-700 bg-lime-200 shadow-[0_0_0_8px_rgba(190,242,100,0.22)]"
+          aria-hidden="true"
+        />
+      </div>
+
+      <details className="group" open={defaultOpen}>
+        <summary className="cursor-pointer list-none text-subheading-1 font-semibold text-slate-900 marker:content-['']">
+          {title}
+        </summary>
+        <p className="my-4 max-w-2xl text-paragraph text-slate-700">{body}</p>
+      </details>
+    </article>
+  );
+}
+
+export default RoadmapItem;

--- a/src/features/Roadmap/RoadmapItem.jsx
+++ b/src/features/Roadmap/RoadmapItem.jsx
@@ -1,6 +1,6 @@
 function RoadmapItem({ year, title, body, defaultOpen = true }) {
   return (
-    <article className="grid grid-cols-[60px_64px_1fr] md:grid-cols-[120px_64px_1fr] gap-x-2 md:gap-x-6 items-start">
+    <article className="grid grid-cols-[60px_64px_1fr] md:grid-cols-[120px_64px_1fr] px-2 gap-x-10 md:gap-x-20 items-start">
       <p className="text-subheading-1 font-semibold text-slate-900 text-end">{year}</p>
 
       {/* vertical connector + dot */}
@@ -16,7 +16,7 @@ function RoadmapItem({ year, title, body, defaultOpen = true }) {
         <summary className="cursor-pointer list-none text-subheading-1 font-semibold text-slate-900 marker:content-['']">
           {title}
         </summary>
-        <p className="my-4 max-w-2xl text-paragraph text-slate-700">{body}</p>
+        <p className="my-4 pb-20 max-w-2xl text-paragraph text-slate-700">{body}</p>
       </details>
     </article>
   );

--- a/src/features/Roadmap/RoadmapItem.jsx
+++ b/src/features/Roadmap/RoadmapItem.jsx
@@ -1,7 +1,7 @@
 function RoadmapItem({ year, title, body, defaultOpen = true }) {
   return (
     <article className="grid grid-cols-[60px_64px_1fr] md:grid-cols-[120px_64px_1fr] px-2 gap-x-10 md:gap-x-20 items-start">
-      <p className="text-subheading-1 font-semibold text-slate-900 text-end">{year}</p>
+      <p className="text-subheading-1 font-semibold text-roadmap-blue text-end">{year}</p>
 
       {/* vertical connector + dot */}
       <div className="relative flex h-full justify-center ">
@@ -13,10 +13,10 @@ function RoadmapItem({ year, title, body, defaultOpen = true }) {
       </div>
 
       <details className="group" open={defaultOpen}>
-        <summary className="cursor-pointer list-none text-subheading-1 font-semibold text-slate-900 marker:content-['']">
+        <summary className="cursor-pointer list-none text-subheading-1 font-semibold text-roadmap-blue marker:content-['']">
           {title}
         </summary>
-        <p className="my-4 pb-20 max-w-2xl text-paragraph text-slate-700">{body}</p>
+        <p className="my-4 pb-20 max-w-2xl text-paragraph text-roadmap-blue">{body}</p>
       </details>
     </article>
   );

--- a/src/features/UI/index.js
+++ b/src/features/UI/index.js
@@ -1,3 +1,5 @@
+import RoadmapItem from "../Roadmap/RoadmapItem";
+
 export { default as Tag } from "./Tag/Tag";
 export { default as Section } from "./Section/Section";
 export { default as TextSection } from "./TextSection/TextSection";

--- a/src/pages/About/About.jsx
+++ b/src/pages/About/About.jsx
@@ -1,6 +1,7 @@
 import { TextSection, TextSectionQuoteAside } from "../../features/UI";
 import { mission } from "./translations/mission";
 import { useT } from "../../stores/languageStore";
+import RoadmapSection from "./sections/Roadmap/Roadmap";
 
 function About() {
   const tMission = useT(mission);
@@ -22,40 +23,7 @@ function About() {
         }
         asideClassName="w-full shrink-0 md:basis-2/5 xl:basis-1/2 mt-6 md:max-w-md lg:max-w-lg xl:max-w-xl"
       />
-      <div className="flex flex-col baseline-start gap-4">
-        {/* <img src="/src/assets/placeholder-img.png" alt="placeholder image" /> */}
-        <h1 className="text-h1 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Heading 1
-        </h1>
-        <h2 className="text-h2 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Heading 2
-        </h2>
-        <h3 className="text-h3 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Heading 3
-        </h3>
-        <h3 className="text-subheading-1 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Sub-Heading 1
-        </h3>
-        <h4 className="text-subheading-2 text-fg text-pretty text-left xs:text-center sm:text-center">
-          Sub-Heading 2
-        </h4>
-
-        <p className="text-body text-fg text-left text-pretty xs:text-center sm:text-center">
-          Empowering developers through community, <br className="hidden xs:block" />
-          collaboration and career opportunities.
-        </p>
-
-        <p className="text-label text-fg text-left text-pretty xs:text-center sm:text-center">
-          Empowering developers through community, <br className="hidden xs:block" />
-          collaboration and career opportunities.
-        </p>
-        <div className="text-center">
-          <button className="btn">Base</button>
-          <button className="btn btn-primary">Primary</button>
-          <button className="btn btn-secondary">Secondary</button>
-          <button className="btn btn-nav">Nav</button>
-        </div>
-      </div>
+      <RoadmapSection />
     </>
   );
 }

--- a/src/pages/About/sections/Roadmap/Roadmap.jsx
+++ b/src/pages/About/sections/Roadmap/Roadmap.jsx
@@ -1,0 +1,30 @@
+import { Section } from "../../../../features/UI";
+import RoadmapItem from "../../../../features/Roadmap/RoadmapItem.jsx";
+import { roadmap } from "../../translations/roadmap";
+import { useT } from "../../../../stores/languageStore";
+
+function RoadmapSection() {
+  const t = useT(roadmap);
+
+  return (
+    <Section className="bg-slate-100 text-slate-900">
+      <div className="mx-auto max-w-5xl">
+        <h2 className="mb-10 text-h2">{t.sectionTitle}</h2>
+
+        <div className="flex flex-col">
+          {t.items.map((item) => (
+            <RoadmapItem
+              key={item.year}
+              year={item.year}
+              title={item.title}
+              body={item.body}
+              defaultOpen={true}
+            />
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}
+
+export default RoadmapSection;

--- a/src/pages/About/sections/Roadmap/Roadmap.jsx
+++ b/src/pages/About/sections/Roadmap/Roadmap.jsx
@@ -7,7 +7,7 @@ function RoadmapSection() {
   const t = useT(roadmap);
 
   return (
-    <Section className="bg-slate-100 text-slate-900">
+    <Section className="bg-primary-100 text-roadmap-blue">
       <div className="mx-auto max-w-5xl">
         <h2 className="mb-10 text-h2">{t.sectionTitle}</h2>
 

--- a/src/pages/About/translations/roadmap.js
+++ b/src/pages/About/translations/roadmap.js
@@ -1,0 +1,42 @@
+export const roadmap = {
+  en: {
+    sectionTitle: "Roadmap",
+    items: [
+      {
+        year: "2024",
+        title: "Foundation",
+        body: "We established the core platform, validated the community model, and launched our first learning initiatives.",
+      },
+      {
+        year: "2025",
+        title: "Growth",
+        body: "We expanded partnerships, improved mentoring programs, and increased project opportunities for juniors.",
+      },
+      {
+        year: "2026",
+        title: "Scale",
+        body: "We are scaling internationally with stronger tooling, better onboarding, and deeper collaboration with companies.",
+      },
+    ],
+  },
+  no: {
+    sectionTitle: "Veikart",
+    items: [
+      {
+        year: "2024",
+        title: "Grunnlag",
+        body: "Vi etablerte kjerneplattformen, validerte community-modellen og lanserte våre første læringsinitiativer.",
+      },
+      {
+        year: "2025",
+        title: "Vekst",
+        body: "Vi utvidet partnerskap, forbedret mentorprogrammer og økte prosjektmuligheter for juniors.",
+      },
+      {
+        year: "2026",
+        title: "Skalering",
+        body: "Vi skalerer internasjonalt med sterkere verktøy, bedre onboarding og tettere samarbeid med selskaper.",
+      },
+    ],
+  },
+};

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -67,6 +67,7 @@
 
 @theme {
   --color-off-white: #fcfdff;
+  --color-roadmap-blue: #012238;
   /* Primary / Blue */
   --color-primary-50: #fcfdff;
   --color-primary-100: #ecf3ff;


### PR DESCRIPTION
This pull request adds a new, fully localized Roadmap section to the About page, replacing the previous placeholder content. It introduces a new `RoadmapItem` component for displaying roadmap milestones, updates translations, and integrates the new section into the UI.

**Roadmap Section Implementation:**

* Added a new `RoadmapSection` component to `src/pages/About/sections/Roadmap/Roadmap.jsx`, which renders a list of roadmap milestones using the new `RoadmapItem` component. This section is fully localized and styled for consistency with the rest of the site.
* Created the `RoadmapItem` component in `src/features/Roadmap/RoadmapItem.jsx` for displaying individual roadmap entries with year, title, and description, including visual timeline elements.
* Added English and Norwegian translations for the roadmap content in `src/pages/About/translations/roadmap.js`.

**Integration and Refactoring:**

* Replaced the placeholder content on the About page with the new `RoadmapSection` component in `src/pages/About/About.jsx`.
* Updated imports and UI index to expose the new `RoadmapItem` component. [[1]](diffhunk://#diff-6d55d48f9f11efba8e499cc8db993f671fb1253029df7148c7505c378ab88894R1-R2) [[2]](diffhunk://#diff-c2b4ddc3c7b5426ed1d4fa43bcfdd6f7355ae31682d3b39a56c68ee568a73070R4)