### PR TITLE
Fix: Filled send icon on submit buttons (match Figma)

### DIFF
--- a/src/features/UI/Buttons/SubmitButton.jsx
+++ b/src/features/UI/Buttons/SubmitButton.jsx
@@ -1,4 +1,4 @@
-import { Send } from "lucide-react";
+import SendFill from "../icons/SendFill";
 
 /**
  * Submit button with optional Send icon.
@@ -13,7 +13,7 @@ function SubmitButton({ children, variant = "primary", icon = false, className =
     <>
       {icon && (
         <span className="" aria-hidden="true">
-          <Send className="btn__icon-submit" />
+          <SendFill className="btn__icon-submit" />
         </span>
       )}
       <span className="btn__label">{children}</span>

--- a/src/features/UI/Buttons/SubmitButton.jsx
+++ b/src/features/UI/Buttons/SubmitButton.jsx
@@ -1,7 +1,7 @@
 import SendFill from "../icons/SendFill";
 
 /**
- * Submit button with optional Send icon.
+ * Submit button with optional send icon.
  *
  * Forwards all additional props (e.g. disabled, type) to the
  * underlying <button> element.
@@ -12,7 +12,7 @@ function SubmitButton({ children, variant = "primary", icon = false, className =
   const content = (
     <>
       {icon && (
-        <span className="" aria-hidden="true">
+        <span aria-hidden="true">
           <SendFill className="btn__icon-submit" />
         </span>
       )}

--- a/src/features/UI/icons/SendFill.jsx
+++ b/src/features/UI/icons/SendFill.jsx
@@ -1,9 +1,6 @@
 /**
  * Filled paper-plane "send" icon
- * Uses `fill="currentColor"` so it inherits the surrounding text color,
- *
- * @param {object} props - Forwarded to the root <svg> (e.g. className, aria-*).
- * @returns {JSX.Element}
+ * Uses `fill="currentColor"` so it inherits the surrounding text color
  */
 function SendFill(props) {
   return (

--- a/src/features/UI/icons/SendFill.jsx
+++ b/src/features/UI/icons/SendFill.jsx
@@ -1,6 +1,9 @@
 /**
  * Filled paper-plane "send" icon
- * Uses `fill="currentColor"` so it inherits the surrounding text color
+ * Uses `fill="currentColor"` so it inherits the surrounding text color,
+ *
+ * @param {object} props - Forwarded to the root <svg> (e.g. className, aria-*).
+ * @returns {JSX.Element}
  */
 function SendFill(props) {
   return (

--- a/src/features/UI/icons/SendFill.jsx
+++ b/src/features/UI/icons/SendFill.jsx
@@ -1,6 +1,6 @@
 /**
  * Filled paper-plane "send" icon
- * Uses `fill="currentColor"` so it inherits the surrounding text color,
+ * Uses `fill="currentColor"` so it inherits the surrounding text color.
  *
  * @param {object} props - Forwarded to the root <svg> (e.g. className, aria-*).
  * @returns {JSX.Element}

--- a/src/features/UI/icons/SendFill.jsx
+++ b/src/features/UI/icons/SendFill.jsx
@@ -1,0 +1,22 @@
+/**
+ * Filled paper-plane "send" icon
+ * Uses `fill="currentColor"` so it inherits the surrounding text color,
+ *
+ * @param {object} props - Forwarded to the root <svg> (e.g. className, aria-*).
+ * @returns {JSX.Element}
+ */
+function SendFill(props) {
+  return (
+    <svg
+      viewBox="0 0 30 30"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M25.2942 7.10773C25.8342 5.61398 24.3867 4.16648 22.8929 4.70773L4.63667 11.3102C3.13792 11.8527 2.95667 13.8977 4.33542 14.6965L10.1629 18.0702L15.3667 12.8665C15.6024 12.6388 15.9182 12.5128 16.2459 12.5156C16.5737 12.5185 16.8872 12.65 17.1189 12.8817C17.3507 13.1135 17.4822 13.427 17.485 13.7547C17.4879 14.0825 17.3619 14.3982 17.1342 14.634L11.9304 19.8377L15.3054 25.6652C16.1029 27.044 18.1479 26.8615 18.6904 25.364L25.2942 7.10773Z" />
+    </svg>
+  );
+}
+
+export default SendFill;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1625,10 +1625,24 @@ label {
   }
 
   .btn__icon-submit {
-    width: 1.875rem;
-    height: 1.875rem;
+    width: 1.25rem;
+    height: 1.25rem;
     flex-shrink: 0;
     color: currentColor;
+  }
+
+  @media (min-width: 768px) {
+    .btn__icon-submit {
+      width: 1.625rem;
+      height: 1.625rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .btn__icon-submit {
+      width: 1.875rem;
+      height: 1.875rem;
+    }
   }
 
   /* Roadmap */

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1625,8 +1625,8 @@ label {
   }
 
   .btn__icon-submit {
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1.875rem;
+    height: 1.875rem;
     flex-shrink: 0;
     color: currentColor;
   }


### PR DESCRIPTION
Contact/apply form submit buttons used Lucide's outline Send icon while Figma uses filled send-fill plane.

- Added  inline SVG icon (src/features/UI/icons/) (Exported icon from figma) and used it in SubmitButton 
- increase .btn__icon-submit from 20px → 30px on desktop, per design

**NOTE/QUESTION:** Added the svg in an icon folder for now. The icon has to flip colour by theme and an `<img>` from assets/ can't inherit currentColor if belive. Rendering inline with fill="currentColor" keeps the same behavior the Lucide icon had. Open to alternatives (e.g. two color variants in assets/, a CSS mask, other?) if we'd rather keep it with the other SVGs/assets.

Changed on all three forms (Home Contact, About Contact, Work With Us Apply).

<img width="168" height="60" alt="Screenshot 2026-06-09 120854" src="https://github.com/user-attachments/assets/8054705a-c334-4098-9fec-9f3d799fadb4" />
<img width="199" height="56" alt="Screenshot 2026-06-09 120922" src="https://github.com/user-attachments/assets/e51d80f4-6453-47a2-95c7-711071dc57d2" />
