### PR TITLE
fix: restore pointer cursor on buttons

### DIFF
--- a/src/features/UI/Buttons/Button.jsx
+++ b/src/features/UI/Buttons/Button.jsx
@@ -53,7 +53,7 @@ function Button({ children, onClick, variant = "primary", size = "md", disabled 
   return (
     <button
       onClick={onClick}
-      className={`rounded-lg border border-transparent font-bold cursor-pointer transition-all duration-250
+      className={`rounded-lg border border-transparent font-bold transition-all duration-250
         ${variants[variant]}
         ${sizes[size]}
         ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -171,6 +171,13 @@ body {
   @apply bg-off-white text-roadmap-blue;
 }
 
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 .dark {
   color-scheme: dark;
 }


### PR DESCRIPTION
Adds the pointer (hand) cursor to button elements (Form submit buttons and the navbar theme toggle were showing the default arrow). 

Since Tailwind v4 no longer add cursor: pointer to buttons by default I added base-layer rule giving non-disabled buttons a pointer cursor. And removed the now redundant cursor-pointer style from the button component