### PR TITLE
fix: html lang sync +  feat: language defaults 

### DIFF
--- a/src/features/Layout/Layout.jsx
+++ b/src/features/Layout/Layout.jsx
@@ -3,6 +3,7 @@ import { Outlet } from "react-router-dom";
 import Header from "./Header/Header";
 import Footer from "./Footer/Footer";
 import { getSystemPreference, useThemeStore } from "../../stores/themeProvider";
+import { useLanguageStore } from "../../stores/languageStore";
 
 function applyTheme(theme) {
   document.documentElement.classList.toggle("dark", theme === "dark");
@@ -10,10 +11,15 @@ function applyTheme(theme) {
 
 function Layout() {
   const userTheme = useThemeStore((state) => state.userTheme);
+  const language = useLanguageStore((state) => state.language);
 
   useEffect(() => {
     applyTheme(useThemeStore.getState().getTheme());
   }, [userTheme]);
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");

--- a/src/stores/languageStore.js
+++ b/src/stores/languageStore.js
@@ -1,10 +1,25 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+// Get language from browser settings (first time visits)
+function getInitialLanguage() {
+  if (typeof navigator === "undefined") return "en";
+
+  const preferred = navigator.languages?.length ? navigator.languages : [navigator.language];
+
+  for (const tag of preferred) {
+    const lower = (tag ?? "").toLowerCase();
+    if (lower.startsWith("nb") || lower.startsWith("nn") || lower.startsWith("no")) return "no";
+    if (lower.startsWith("en")) return "en";
+  }
+
+  return "en";
+}
+
 export const useLanguageStore = create(
   persist(
     (set) => ({
-      language: "en",
+      language: getInitialLanguage(),
       setLanguage: (lang) => set({ language: lang }),
       toggleLanguage: () => set((state) => ({ language: state.language === "en" ? "no" : "en" })),
     }),


### PR DESCRIPTION
Fix:
- Sync <html lang> with the selected language. It was hardcoded to en and never updated on toggle, so Norwegian content would read with English pronunciation by screen readers (WCAG 3.1.1/3.1.2)

Added:
- Default first-time visitors to their browser language (then saved toggle choice still takes priority)