### PR TITLE
Remove service card footer and align cards to Figma

### DIFF
--- a/src/features/ServiceCard/ServiceCard.jsx
+++ b/src/features/ServiceCard/ServiceCard.jsx
@@ -1,12 +1,9 @@
-import { Link } from "react-router-dom";
-import { ArrowUpRight } from "lucide-react";
 import { Tag } from "../UI";
 
 /**
  * Service preview card.
  *
  * @param {object} props
- * @param {string} props.id - Service identifier used in route
  * @param {string} props.title - Service title
  * @param {string} props.details - Short service description
  * @param {string[]} props.tags - Tags shown in the card
@@ -16,7 +13,6 @@ import { Tag } from "../UI";
  * @returns {JSX.Element}
  */
 function ServiceCard({
-  // id,
   title,
   details,
   tags,
@@ -25,7 +21,7 @@ function ServiceCard({
   tagClassName = "",
 }) {
   return (
-    <Link to={`#`} className={`service-card ${className}`}>
+    <article className={`service-card ${className}`}>
       <div className={`service-card__panel ${panelClassName}`}>
         <h3 className="service-card__title">{title}</h3>
         <p className="service-card__details">{details}</p>
@@ -37,14 +33,7 @@ function ServiceCard({
           ))}
         </div>
       </div>
-      {/* This could be a component if its something we want to use elsewhere */}
-      <div className="service-card__footer">
-        <span className="service-card__action">Explore</span>
-        <span className="service-card__icon-wrap" aria-hidden="true">
-          <ArrowUpRight className="service-card__icon" />
-        </span>
-      </div>
-    </Link>
+    </article>
   );
 }
 

--- a/src/pages/Home/sections/Services.jsx
+++ b/src/pages/Home/sections/Services.jsx
@@ -18,7 +18,6 @@ function OurServices() {
             return (
               <ServiceCard
                 key={card.id}
-                id={card.id}
                 title={content.title}
                 details={content.details}
                 tags={content.tags}

--- a/src/pages/Home/translations/services.js
+++ b/src/pages/Home/translations/services.js
@@ -37,7 +37,7 @@ export const serviceCards = [
       details: "lorem ipsumlorem ipsumlorem ipsum",
       tags: ["Nettside", "Nettside", "Nettside"],
     },
-    panelClassName: "bg-secondary-500 hover:bg-secondary-600 text-roadmap-blue",
+    panelClassName: "bg-secondary-200 hover:bg-secondary-600 text-roadmap-blue",
     tagClassName: "bg-secondary-200 text-roadmap-blue",
   },
   {

--- a/src/pages/Home/translations/services.js
+++ b/src/pages/Home/translations/services.js
@@ -37,8 +37,8 @@ export const serviceCards = [
       details: "lorem ipsumlorem ipsumlorem ipsum",
       tags: ["Nettside", "Nettside", "Nettside"],
     },
-    panelClassName: "bg-secondary-200 hover:bg-secondary-600 text-roadmap-blue",
-    tagClassName: "bg-secondary-200 text-roadmap-blue",
+    panelClassName: "bg-secondary-200 hover:bg-secondary-500 text-roadmap-blue",
+    tagClassName: "bg-secondary-300 text-roadmap-blue",
   },
   {
     id: "backend",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -301,10 +301,6 @@ body {
   color: var(--color-primary-50);
 }
 
-.dark .service-card .text-roadmap-blue {
-  color: var(--color-roadmap-blue);
-}
-
 .dark .service-card__tags .bg-primary-100 {
   background-color: var(--color-primary-100);
 }
@@ -1225,15 +1221,6 @@ label {
     @apply flex flex-col max-w-lg overflow-hidden rounded-[0.3125rem] border border-primary-200 bg-off-white transition-colors duration-200;
   }
 
-  .service-card:hover {
-    @apply shadow-[0_1px_4px_4px_rgba(116,153,3,0.09)];
-  }
-
-  .service-card:focus-visible {
-    @apply outline-none border-primary-600;
-    box-shadow: 0 0 0 2px var(--color-primary-600);
-  }
-
   .service-card__panel {
     @apply flex-1 flex flex-col m-1 rounded-[0.1875rem] p-3.5 pt-4;
     min-height: 9rem;
@@ -1255,29 +1242,6 @@ label {
     @apply mt-auto flex flex-wrap gap-2;
   }
 
-  .service-card__footer {
-    @apply flex items-center justify-between px-4 pb-4 pt-2;
-  }
-
-  .service-card__action {
-    font-family: var(--font-body);
-    font-size: 1.25rem;
-    line-height: 1.2;
-    font-weight: 500;
-    color: var(--color-roadmap-blue);
-  }
-
-  .service-card__icon-wrap {
-    @apply inline-flex items-center justify-center rounded-full bg-primary-100 text-roadmap-blue;
-    width: 2rem;
-    height: 2rem;
-  }
-
-  .service-card__icon {
-    width: 1rem;
-    height: 1rem;
-  }
-
   @media (min-width: 768px) {
     .services-rail {
       gap: 1rem;
@@ -1293,20 +1257,6 @@ label {
     .service-card__details {
       @apply mb-9.5;
       font-size: 1rem;
-    }
-
-    .service-card__action {
-      font-size: 1.875rem;
-    }
-
-    .service-card__icon-wrap {
-      width: 2.5rem;
-      height: 2.5rem;
-    }
-
-    .service-card__icon {
-      width: 1.25rem;
-      height: 1.25rem;
     }
   }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1223,7 +1223,7 @@ label {
   }
 
   .service-card__panel {
-    @apply flex-1 flex flex-col m-1.5 rounded-[3px] p-3.5 pt-4;
+    @apply flex-1 flex flex-col m-[3.4%] rounded-[3px] p-3.5 pt-4;
     min-height: 9rem;
   }
 
@@ -1251,11 +1251,11 @@ label {
     }
 
     .service-card {
-      @apply rounded-[6.87px] border-[1px];
+      @apply rounded-[6.87px] border;
     }
 
     .service-card__panel {
-      @apply m-[8.25px] rounded-[4.13px] p-5;
+      @apply rounded-[4.13px] p-5;
       min-height: 11rem;
     }
 
@@ -1271,7 +1271,7 @@ label {
     }
 
     .service-card__panel {
-      @apply m-[15px] rounded-[7.69px];
+      @apply rounded-[7.69px];
     }
 
     .service-card__details {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1223,12 +1223,12 @@ label {
   }
 
   .service-card {
-    @apply flex flex-col max-w-lg overflow-hidden rounded-[5px] border-[0.5px] border-card-border bg-off-white transition-colors duration-200;
+    @apply flex flex-col max-w-lg overflow-hidden rounded-md border-[0.5px] border-card-border bg-off-white transition-colors duration-200;
   }
 
   .service-card__panel {
-    @apply flex-1 flex flex-col rounded-[3px] p-3.5 pt-4;
-    margin: min(3.4%, 8px);
+    @apply flex-1 flex flex-col rounded-sm p-3.5 pt-4;
+    margin: min(3.4%, 0.5rem);
     min-height: 9rem;
   }
 
@@ -1256,11 +1256,11 @@ label {
     }
 
     .service-card {
-      @apply rounded-[6.87px] border;
+      @apply border;
     }
 
     .service-card__panel {
-      @apply rounded-[4.13px] p-5;
+      @apply p-5;
       min-height: 11rem;
     }
 
@@ -1272,11 +1272,11 @@ label {
 
   @media (min-width: 1024px) {
     .service-card {
-      @apply rounded-[12.81px] border-[1.5px];
+      @apply rounded-xl border-[1.5px];
     }
 
     .service-card__panel {
-      @apply rounded-[7.69px];
+      @apply rounded-lg;
     }
 
     .service-card__details {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -302,6 +302,10 @@ body {
   color: var(--color-primary-50);
 }
 
+.dark .service-card .text-roadmap-blue {
+  color: var(--color-roadmap-blue);
+}
+
 .dark .service-card__tags .bg-primary-100 {
   background-color: var(--color-primary-100);
 }
@@ -1223,7 +1227,8 @@ label {
   }
 
   .service-card__panel {
-    @apply flex-1 flex flex-col m-[3.4%] rounded-[3px] p-3.5 pt-4;
+    @apply flex-1 flex flex-col rounded-[3px] p-3.5 pt-4;
+    margin: min(3.4%, 8px);
     min-height: 9rem;
   }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -92,6 +92,7 @@
   --color-secondary-800: #5e7c04;
   --color-secondary-900: #3c4f03;
   /* Figma-exact accents (revert on request) */
+  --color-card-border: #fcfdff;
   --color-card-blue-border: #033dd7;
   --color-accent-lime: #ceff29;
   --color-figma-green: #5e7c04;
@@ -1218,11 +1219,11 @@ label {
   }
 
   .service-card {
-    @apply flex flex-col max-w-lg overflow-hidden rounded-[0.3125rem] border border-primary-200 bg-off-white transition-colors duration-200;
+    @apply flex flex-col max-w-lg overflow-hidden rounded-[5px] border-[0.5px] border-card-border bg-off-white transition-colors duration-200;
   }
 
   .service-card__panel {
-    @apply flex-1 flex flex-col m-1 rounded-[0.1875rem] p-3.5 pt-4;
+    @apply flex-1 flex flex-col m-1.5 rounded-[3px] p-3.5 pt-4;
     min-height: 9rem;
   }
 
@@ -1249,8 +1250,12 @@ label {
       padding-bottom: 0.5rem;
     }
 
+    .service-card {
+      @apply rounded-[6.87px] border-[1px];
+    }
+
     .service-card__panel {
-      @apply p-5;
+      @apply m-[8.25px] rounded-[4.13px] p-5;
       min-height: 11rem;
     }
 
@@ -1261,6 +1266,14 @@ label {
   }
 
   @media (min-width: 1024px) {
+    .service-card {
+      @apply rounded-[12.81px] border-[1.5px];
+    }
+
+    .service-card__panel {
+      @apply m-[15px] rounded-[7.69px];
+    }
+
     .service-card__details {
       @apply mb-16;
       font-size: 1.875rem;


### PR DESCRIPTION
Removes the (currently) non-functional "Explore" footer from the home page service cards. And aligns the cards to the Figma design.

- Footer removed. Cursor: pointer is gone, but I left the colour change when hovering over them for now
- Card border, radius, and inset matched (I tried at least) to the Figma spec on mobile, tablet, and desktop
- removed the blue border line and added a `card-border` token (`#fcfdff`) instead (matching figma).
- Changed to the correct lime colour on the second card panel and tags. 

<img width="842" height="266" alt="image" src="https://github.com/user-attachments/assets/b229b1f2-8471-4c4f-8080-2aec9d3cf1db" />

