### PR TITLE
fix: enforce 0% minimum letter spacing site-wide

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -43,6 +43,7 @@
 
   --leading-heading: 1.44;
   --leading-body: 1.44;
+  --letter-spacing-body: 0;
 }
 
 @media (min-width: 768px) {
@@ -175,6 +176,10 @@
   --text-caption: 0.75rem; /* 12px */
   --text-caption--line-height: 1rem;
   --text-caption--font-weight: 400;
+
+  /* Letter spacing — never below 0 (Figma 0% minimum) */
+  --tracking-tighter: 0em;
+  --tracking-tight: 0em;
 }
 
 body {
@@ -184,6 +189,10 @@ body {
 }
 
 @layer base {
+  html {
+    letter-spacing: var(--letter-spacing-body);
+  }
+
   button:not(:disabled),
   [role="button"]:not(:disabled) {
     cursor: pointer;
@@ -903,7 +912,7 @@ summary.roadmap-item__title.text-subheading-1 {
     font-size: var(--text-label);
     line-height: 1.2;
     font-weight: 300;
-    letter-spacing: -0.0625rem;
+    letter-spacing: var(--letter-spacing-body);
   }
 
   .footer-link:hover {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -908,10 +908,11 @@ summary.roadmap-item__title.text-subheading-1 {
 
   .footer-link {
     @apply text-off-white transition-colors duration-200;
-    font-family: var(--font-body);
+    font-family: var(--font-body-light);
     font-size: var(--text-label);
     line-height: 1.2;
     font-weight: 300;
+    font-synthesis: none;
     letter-spacing: var(--letter-spacing-body);
   }
 
@@ -926,7 +927,7 @@ summary.roadmap-item__title.text-subheading-1 {
 
   .footer-link--active {
     @apply text-secondary-400;
-    font-weight: 500;
+    font-weight: 300;
   }
 
   .footer-copyright {


### PR DESCRIPTION
Remove negative letter spacing on footer links and set a global baseline so text is no longer horizontally compressed.

<img width="3715" height="1220" alt="image" src="https://github.com/user-attachments/assets/21055226-62dc-4347-92e8-20fb05dfdc47" />
